### PR TITLE
Add track progress bar with fade-in/fade-out effects

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -35,7 +35,7 @@ useWakeLock()
 const connected = ref(false)
 const authenticated = ref(false)
 const track = ref(null)
-const playback = ref({ position: 0, timestamp: Date.now() })
+const playback = ref({ position: 0, duration: 0, timestamp: Date.now() })
 const colors = ref({ bg: '#121212', text: '#ffffff' })
 const spectrumColors = ref(null)
 
@@ -90,7 +90,7 @@ onMounted(() => {
   })
 
   socket.on('playback-position', (data) => {
-    playback.value = { position: data.position, timestamp: Date.now() }
+    playback.value = { position: data.position, duration: data.duration, timestamp: Date.now() }
   })
 
   socket.on('playback-stopped', () => {

--- a/client/src/components/NowPlaying.vue
+++ b/client/src/components/NowPlaying.vue
@@ -9,6 +9,9 @@
       :artist="track?.artist"
       :album="track?.album"
     />
+    <TrackProgress
+      :playback="playback"
+    />
     <SpectrumAnalyzer
       :trackId="track?.trackId"
       :playback="playback"
@@ -24,6 +27,7 @@
 <script setup>
 import AlbumArt from './AlbumArt.vue'
 import TrackInfo from './TrackInfo.vue'
+import TrackProgress from './TrackProgress.vue'
 import SpectrumAnalyzer from './SpectrumAnalyzer.vue'
 
 defineProps({

--- a/client/src/components/TrackProgress.vue
+++ b/client/src/components/TrackProgress.vue
@@ -1,0 +1,95 @@
+<template>
+  <div class="track-progress">
+    <div class="track-progress__bar">
+      <div class="track-progress__fill" :style="{ width: progressPercent + '%' }"></div>
+    </div>
+    <div class="track-progress__times">
+      <span>{{ elapsedFormatted }}</span>
+      <span>-{{ remainingFormatted }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, onUnmounted } from 'vue'
+
+const props = defineProps({
+  playback: { type: Object, default: () => ({ position: 0, duration: 0, timestamp: Date.now() }) }
+})
+
+const progressPercent = ref(0)
+const elapsedFormatted = ref('0:00')
+const remainingFormatted = ref('0:00')
+
+let animFrame = null
+
+function formatTime(ms) {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000))
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`
+}
+
+function update() {
+  const p = props.playback
+  if (!p || !p.duration) {
+    progressPercent.value = 0
+    elapsedFormatted.value = '0:00'
+    remainingFormatted.value = '0:00'
+    animFrame = requestAnimationFrame(update)
+    return
+  }
+
+  const elapsed = p.position + (Date.now() - p.timestamp)
+  const clamped = Math.max(0, Math.min(elapsed, p.duration))
+
+  progressPercent.value = (clamped / p.duration) * 100
+  elapsedFormatted.value = formatTime(clamped)
+  remainingFormatted.value = formatTime(p.duration - clamped)
+
+  animFrame = requestAnimationFrame(update)
+}
+
+onMounted(() => {
+  animFrame = requestAnimationFrame(update)
+})
+
+onUnmounted(() => {
+  if (animFrame) cancelAnimationFrame(animFrame)
+})
+</script>
+
+<style scoped>
+.track-progress {
+  width: 100%;
+  max-width: 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.track-progress__bar {
+  width: 100%;
+  height: 3px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 1.5px;
+  overflow: hidden;
+}
+
+.track-progress__fill {
+  height: 100%;
+  background: currentColor;
+  opacity: 0.5;
+  border-radius: 1.5px;
+}
+
+.track-progress__times {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.65rem;
+  font-weight: 400;
+  opacity: 0.35;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+}
+</style>

--- a/client/src/composables/useAudioAnalysis.js
+++ b/client/src/composables/useAudioAnalysis.js
@@ -50,17 +50,29 @@ function buildBandOscillators(seed) {
   return oscillators
 }
 
+// Smoothstep easing — gentle start and end
+function smoothstep(t) {
+  t = Math.max(0, Math.min(1, t))
+  return t * t * (3 - 2 * t)
+}
+
+const FADE_IN_DURATION = 1.5  // seconds to ramp up on new track
+const FADE_OUT_WINDOW = 5     // seconds before track end to start fading
+
 export function useAudioAnalysis(trackId, playback) {
   const bands = ref(new Array(NUM_BANDS).fill(0))
   const peaks = ref(new Array(NUM_BANDS).fill(0))
+  const fade = ref(1)
   let animFrame = null
   let startTime = 0
   let startPosition = 0
+  let duration = 0
 
   // Per-track state
   let bpm = 120
   let oscillators = []
   let beatPhase = 0
+  let fadeInStart = 0
 
   function applyTrack(id) {
     if (!id) return
@@ -68,10 +80,28 @@ export function useAudioAnalysis(trackId, playback) {
     bpm = deriveTempo(seed)
     oscillators = buildBandOscillators(seed)
     beatPhase = (seed & 0xff) / 255 * Math.PI * 2
+    fadeInStart = Date.now()
   }
 
   function getCurrentPosition() {
     return startPosition + (Date.now() - startTime) / 1000
+  }
+
+  function computeFade(positionSec) {
+    // Fade-in: ramp 0→1 over FADE_IN_DURATION after track change
+    const fadeInElapsed = (Date.now() - fadeInStart) / 1000
+    const fadeIn = smoothstep(Math.min(1, fadeInElapsed / FADE_IN_DURATION))
+
+    // Fade-out: ramp 1→0 in last FADE_OUT_WINDOW seconds of the track
+    let fadeOut = 1
+    if (duration > 0) {
+      const remaining = duration - positionSec
+      if (remaining < FADE_OUT_WINDOW) {
+        fadeOut = smoothstep(Math.max(0, remaining / FADE_OUT_WINDOW))
+      }
+    }
+
+    return fadeIn * fadeOut
   }
 
   const PEAK_DECAY = 0.015
@@ -84,6 +114,9 @@ export function useAudioAnalysis(trackId, playback) {
     }
 
     const t = getCurrentPosition()
+    const currentFade = computeFade(t)
+    fade.value = currentFade
+
     const beatInterval = 60 / bpm
     // Pulsing envelope synced to the derived BPM
     const beatT = ((t / beatInterval) + beatPhase) % 1
@@ -100,7 +133,9 @@ export function useAudioAnalysis(trackId, playback) {
       // Mix in the beat pulse — lower bands feel it more
       const beatWeight = 0.4 * (1 - b / NUM_BANDS)
       val = val * (1 - beatWeight) + beatPulse * beatWeight
-      computed[b] = Math.max(0, Math.min(1, val))
+      // Apply fade multiplier so bars wind down near track end
+      // and ramp up on new track start
+      computed[b] = Math.max(0, Math.min(1, val)) * currentFade
     }
 
     const curBands = bands.value
@@ -126,6 +161,7 @@ export function useAudioAnalysis(trackId, playback) {
     if (p) {
       startPosition = (p.position || 0) / 1000
       startTime = p.timestamp || Date.now()
+      if (p.duration) duration = p.duration / 1000
     }
   }, { immediate: true })
 
@@ -135,5 +171,5 @@ export function useAudioAnalysis(trackId, playback) {
     if (animFrame) cancelAnimationFrame(animFrame)
   })
 
-  return { bands, peaks }
+  return { bands, peaks, fade }
 }


### PR DESCRIPTION
## Summary
This PR adds a visual track progress indicator and implements smooth fade-in/fade-out effects for the audio analysis visualization. The progress bar displays elapsed and remaining time, while the spectrum analyzer now gracefully ramps up when a new track starts and winds down as the track approaches its end.

## Key Changes
- **New TrackProgress component**: Displays a progress bar with elapsed/remaining time formatted as MM:SS, updating smoothly via requestAnimationFrame
- **Fade effects in audio analysis**: 
  - Fade-in over 1.5 seconds when a new track begins
  - Fade-out over the last 5 seconds of playback
  - Uses smoothstep easing for gentle transitions
- **Enhanced playback tracking**: Added `duration` field to playback state to enable fade-out calculations
- **Integrated progress display**: TrackProgress component now rendered in NowPlaying layout between track info and spectrum analyzer

## Implementation Details
- The TrackProgress component calculates current position by interpolating from the last known position and timestamp, ensuring smooth visual updates independent of network latency
- Time formatting handles edge cases (zero duration, negative values) gracefully
- The fade multiplier is computed based on both elapsed time since track change and remaining time until track end, then applied to all spectrum bands
- Animation frames are properly cleaned up on component unmount to prevent memory leaks

https://claude.ai/code/session_01D1xSgDjJzyL9MQ4key3hSc