### PR TITLE
Update README with multiple screenshot examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 A real-time **now playing** display for Spotify, designed to turn an iPhone into a dedicated always-on music screen.
 
 <p align="center">
-  <img src="images/scr_1.png" alt="TuneBoss displaying album art, track info, progress bar, and spectrum analyzer" width="300">
+  <img src="images/scr_2.png" alt="TuneBoss screenshot 1" width="250">&nbsp;&nbsp;
+  <img src="images/scr_3.png" alt="TuneBoss screenshot 2" width="250">&nbsp;&nbsp;
+  <img src="images/scr_4.png" alt="TuneBoss screenshot 3" width="250">
 </p>
 
 TuneBoss polls the Spotify Web API and pushes track updates over WebSocket to a Vue 3 PWA. The display renders album art, track metadata, a progress bar, and a 10-band spectrum analyzer — all with dynamic color theming extracted from the cover art.


### PR DESCRIPTION
## Summary
Updated the README documentation to showcase multiple screenshots of the TuneBoss application instead of a single image.

## Changes
- Replaced single screenshot (`scr_1.png`) with three new screenshots (`scr_2.png`, `scr_3.png`, `scr_4.png`)
- Adjusted image width from 300px to 250px per image to accommodate three screenshots in a row
- Added spacing between images using non-breaking spaces
- Updated alt text to be more generic ("TuneBoss screenshot 1/2/3") for the multiple images

## Details
This change provides a more comprehensive visual overview of the application's interface by displaying three different views or states of TuneBoss, giving potential users a better understanding of the app's capabilities and design.

https://claude.ai/code/session_01DJa4YdDYe2QqNDgzeyYfVU